### PR TITLE
chore: standardize files

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ bot.help(({ replyWithMarkdown }) => replyWithMarkdown(`
   /pd - Retorna a performance detalhada do dia do Monetus FIA.
 `))
 
-function formatDelta(delta) {
+function formatDelta (delta) {
   if (delta > 0) {
     return `+${delta}%`
   } else {
@@ -27,7 +27,7 @@ function formatDelta(delta) {
   }
 }
 
-function parseCommand(text) {
+function parseCommand (text) {
   const parts = text.split(' ')
 
   const command = parts[0].toLowerCase().trim()
@@ -41,7 +41,7 @@ function parseCommand(text) {
 let lastCommands = {}
 const min = 300000 // 5 minutes in milliseconds
 
-function throttle(reply, message, ignoreArgs) {
+function throttle (reply, message, ignoreArgs) {
   const c = parseCommand(message.text)
 
   let k = message.chat.id.toString() + c.command
@@ -66,12 +66,12 @@ function throttle(reply, message, ignoreArgs) {
 
 // Composition
 bot.command('c', ({ replyWithMarkdown }) => {
-  let comp = '';
+  let comp = ''
 
   portfolio.composition.forEach((asset) => (
     comp += `
 *${asset.ticker} (${asset.name})*
-_Alocação_: ${asset.allocation/100}%
+_Alocação_: ${asset.allocation / 100}%
     `
   ))
 
@@ -93,7 +93,7 @@ bot.command('d', ({ replyWithMarkdown, message: { text } }) => {
   replyWithMarkdown(`
     *${asset.ticker} (${asset.name})*
 
-_Alocação_: ${asset.allocation/100}%
+_Alocação_: ${asset.allocation / 100}%
 
 _Descrição_: ${asset.description}
   `)
@@ -141,12 +141,12 @@ bot.command('pd', ({ replyWithMarkdown, message }) => {
   if (throttle(replyWithMarkdown, message, true)) return
 
   portfolio.fetchPerformance().then((performance) => {
-    let comp = '';
+    let comp = ''
 
     performance.assets.forEach((asset) => (
       comp += `
   *${asset.ticker} (${asset.name})*
-  _Alocação_: ${asset.allocation/100}%
+  _Alocação_: ${asset.allocation / 100}%
   _Delta_: ${formatDelta(asset.quote.delta)}
       `
     ))

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "dev": "supervisor -x micro-bot index.js",
     "start": "micro-bot",
-    "now-start": "micro-bot -d ${NOW_URL}",
     "lint": "eslint .",
     "test": "npm run lint"
   },

--- a/portfolio.js
+++ b/portfolio.js
@@ -120,11 +120,11 @@ const composition = [
   }
 ]
 
-function round(num) {
+function round (num) {
   return Math.round(parseFloat(num) * 100) / 100
 }
 
-function yahooQuote(ticker) {
+function yahooQuote (ticker) {
   return new Promise((resolve, reject) => {
     yahoo
       .getHistoricalData(`${ticker}.SA`, '1d', '1d')
@@ -147,28 +147,28 @@ function yahooQuote(ticker) {
         resolve(q)
       }).catch((err) => {
         console.log(err)
-        reject('Serviço temporariamente fora do ar, por favor, tente mais tarde.')
+        reject(new Error('Serviço temporariamente fora do ar, por favor, tente mais tarde.'))
       })
   })
 }
 
-function yahooQuotes(tickers) {
+function yahooQuotes (tickers) {
   let quotes = []
 
   tickers.forEach((ticker) => {
     quotes.push(yahooQuote(ticker))
   })
 
-  return Promise.all(quotes);
+  return Promise.all(quotes)
 }
 
 const portfolio = {
   composition,
-  getAsset: function(ticker) {
+  getAsset: function (ticker) {
     return composition.find((asset) => asset.ticker === ticker.toUpperCase())
   },
   fetchQuote: yahooQuote,
-  fetchPerformance: function() {
+  fetchPerformance: function () {
     let performance = {
       assets: []
     }


### PR DESCRIPTION
This PR aims to fix a few ESLint errors and removes the command `now-start` from `package.json` file.

Removing the `now-start` command is a decision based on the lack of Now (https://zeit.co/now) service usage. It was introduced by `micro-bot` scaffold command.