### PR TITLE
Simplify `dev` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "dev": "supervisor -x micro-bot index.js",
+    "dev": "supervisor -x micro-bot -- index.js -e",
     "start": "micro-bot",
     "lint": "eslint .",
     "test": "yarn lint && yarn jest"


### PR DESCRIPTION
Instead of explicitly pass `BOT_TOKEN` while executing `yarn dev`, it uses the command `-e` from `micro-bot` to load the _env key_ from the `.env` file (default value from the command).

## TODO

* [x] Update `dev` command on `package.json`
* [ ] Update _readme_ usage